### PR TITLE
Add ability to Publish to sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization := "io.github.fucusy"
 name := "dataframe2html"
-version := "0.1.1-SNAPSHOT"
+version := "0.1.2"
 scalaVersion := "2.11.10"
 
 val sparkVersion  = "2.4.3"
@@ -12,8 +12,9 @@ libraryDependencies ++= Seq(
                             "org.apache.spark" %% "spark-sql"      % sparkVersion % "provided"
 )
 
-useGpg := true
+
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
+
 
 ThisBuild / organization := "io.github.fucusy"
 ThisBuild / organizationName := "Fucusy"
@@ -46,3 +47,7 @@ ThisBuild / publishTo := {
   else Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 ThisBuild / publishMavenStyle := true
+
+import xerial.sbt.Sonatype._
+publishTo := sonatypePublishToBundle.value
+sonatypeBundleDirectory := (ThisBuild / baseDirectory).value / target.value.getName / "sonatype-staging" / s"${version.value}"

--- a/build.sbt
+++ b/build.sbt
@@ -7,3 +7,37 @@ scalaVersion := "2.12.10"
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.1.1"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.1" % "test"
 
+useGpg := true
+credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
+
+ThisBuild / organization := "io.github.fucusy"
+ThisBuild / organizationName := "Fucusy"
+ThisBuild / organizationHomepage := Some(url("https://github.com/fucusy"))
+
+ThisBuild / scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/fucusy/dataframe2html"),
+    "scm:git@github.com:fucusy/dataframe2html.git"
+  )
+)
+ThisBuild / developers := List(
+  Developer(
+    id    = "fucusy",
+    name  = "Qiang Chen",
+    email = "fucus.me@gmail.com",
+    url   = url("https://github.com/fucusy")
+  )
+)
+
+ThisBuild / description := "Make the ability to show the image and the data of dataframe in notebook."
+ThisBuild / licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / homepage := Some(url("https://github.com/fucusy/dataframe2html"))
+
+// Remove all additional repository other than Maven Central from POM
+ThisBuild / pomIncludeRepository := { _ => false }
+ThisBuild / publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+  else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
+ThisBuild / publishMavenStyle := true

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-organization := "fucusy"
+organization := "io.github.fucusy"
 name := "dataframe2html"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.12.10"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.7")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")


### PR DESCRIPTION
Result: https://dbc-5f2acc18-b29d.cloud.databricks.com/?o=6211501775943445#notebook/2550389456833954/command/2550389456833978



Follow by https://www.scala-sbt.org/release/docs/Using-Sonatype.html
Build the ability to publish to sonatype by sbt manually, with a few setup, 
and run `sbt publishSigned` to creat a staging result, 
`sbt sonatypeBundleRelease ` to publish the project,  will be synchronized to the Maven central within ten minutes.


to remove the SNAPSHOT in the version before `sbt publishSigned` to make a release 